### PR TITLE
FIX: Correcciones al crear usuarios desde la interfaz

### DIFF
--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -124,7 +124,7 @@ class ResPartner(models.Model):
         if self.city_id:
             return {'value':{'city': self.city_id.name}}
 
-    @api.constrains('vat')
+    @api.constrains('vat', 'commercial_partner_id')
     def _rut_unique(self):
         for r in self:
             if not r.vat or r.parent_id:
@@ -136,7 +136,7 @@ class ResPartner(models.Model):
                     ('commercial_partner_id', '!=', r.commercial_partner_id.id),
                 ])
             if r.vat !="CL555555555" and partner:
-                raise UserError(_('El rut debe ser único'))
+                raise UserError(_('El rut: %s debe ser único') % r.vat)
                 return False
 
     def check_vat_cl(self, vat):

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -133,7 +133,7 @@ class ResPartner(models.Model):
                 [
                     ('vat','=', r.vat),
                     ('id','!=', r.id),
-                    ('parent_id', '!=', r.id),
+                    ('commercial_partner_id', '!=', r.commercial_partner_id.id),
                 ])
             if r.vat !="CL555555555" and partner:
                 raise UserError(_('El rut debe ser único'))

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -101,9 +101,9 @@ class ResPartner(models.Model):
             if exist:
                 self.vat = ''
                 self.document_number = ''
-                raise UserError(
-                            _("El usuario %s está utilizando este documento" ) % exist.name,
-                    )
+                return {'warning': {'title': 'Informacion para el Usuario',
+                                    'message': _("El usuario %s está utilizando este documento" ) % exist.name, 
+                                    }}
             self.vat = vat
             self.document_number = '%s.%s.%s-%s' % (
                                         document_number[0:2], document_number[2:5],


### PR DESCRIPTION
en eventos onchange para mostrar mensajes al usuario no se debe lanzar excepciones, esto no refresca la UI, mostrar warning para el mensaje y asi actualizar la UI tambien, esto borra el RUT cuando esta siendo usado por otra empresa y obliga al usuario a corregir el RUT(antes del cambio, si el RUT ya existe en otra empresa, se muestrs mensaje pero no se borra el RUT, dando la impresion que se acepto el RUT pero al guardar el registro, desaparece el RUT, dando la impresion que el sistema esta loco y se perdio el RUT)

Corrije en parte el bug [17 reportado en punto de venta](https://github.com/dansanti/l10n_cl_dte_point_of_sale/issues/17)