### PR TITLE
FIX: evitar porcentajes de uso fuera de 0-100 cuando hay multiples CAF

### DIFF
--- a/models/caf.py
+++ b/models/caf.py
@@ -122,7 +122,12 @@ has been exhausted.''',
             if r.status not in [ 'draft' ]:
                 folio = r.sequence_id.number_next_actual
                 try:
-                    r.use_level = 100.0 * ((int(folio) - r.start_nm) / float(r.final_nm - r.start_nm + 1))
+                    if folio > r.final_nm:
+                        r.use_level = 100
+                    elif folio < r.start_nm:
+                        r.use_level = 0
+                    else:
+                        r.use_level = 100.0 * ((int(folio) - r.start_nm) / float(r.final_nm - r.start_nm + 1))
                 except ZeroDivisionError:
                     r.use_level = 0
             else:

--- a/models/caf.py
+++ b/models/caf.py
@@ -170,7 +170,7 @@ class sequence_caf(models.Model):
                 if folio >= c.start_nm and folio <= c.final_nm:
                     available += c.final_nm - folio
                 elif folio <= c.final_nm:
-                    available +=  c.final_nm - c.start_nm
+                    available +=  (c.final_nm - c.start_nm) + 1
                 if folio > c.start_nm:
                     available +=1
         return available


### PR DESCRIPTION
Esta es la solucion para el commit #29 luego de esto se ven asi los CAF
![image](https://user-images.githubusercontent.com/7775116/36048413-26977870-0dad-11e8-803d-eac5bedb7329.png)


**Si modifico el proximo numero, digamos que en 6**
Antes:
![image](https://user-images.githubusercontent.com/7775116/36048543-91dd64dc-0dad-11e8-946a-000fbe804560.png)


Despues del cambio
![image](https://user-images.githubusercontent.com/7775116/36048475-5e4b552a-0dad-11e8-8aaf-ad806c4d3cd9.png)

**Si proximo numero fuera 15**
Antes
![image](https://user-images.githubusercontent.com/7775116/36048720-2616f9ce-0dae-11e8-9d37-b728e7a98ae2.png)

Despues
![image](https://user-images.githubusercontent.com/7775116/36048742-489eaf5a-0dae-11e8-82d2-23423d71a911.png)


