### PR TITLE
FIX: campo price_total no se esta calculando, es necesario cuando se …

### DIFF
--- a/models/invoice.py
+++ b/models/invoice.py
@@ -136,7 +136,11 @@ class AccountInvoiceLine(models.Model):
             sign = line.invoice_id.type in ['in_refund', 'out_refund'] and -1 or 1
             line.price_subtotal_signed = price_subtotal_signed * sign
             line.price_tax_included = taxes['total_included'] if (taxes and taxes['total_included'] > total) else total
+            line.price_total = taxes['total_included'] if (taxes and taxes['total_included'] > total) else total
 
+    # TODO: eliminar este campo en versiones futuras
+    # odoo en V11 ya agrega un campo para guardar el precio incluido impuestos
+    # este campo es innecesario a partir de V11
     price_tax_included = fields.Monetary(string='Amount', readonly=True, compute='_compute_price')
 
 class Referencias(models.Model):


### PR DESCRIPTION
…habilita la configuracion Mostar Precios con impuestos

En V11 se agrego un [nuevo campo](https://github.com/odoo/odoo/blob/11.0/addons/account/models/account_invoice.py#L1463) para guardar el Total incluido el impuesto, pero como reemplazas la [funcion _compute_price](https://github.com/dansanti/l10n_cl_fe/blob/11.0/models/invoice.py#L120-L138) dejas sin calcular el nuevo campo.

![image](https://user-images.githubusercontent.com/7775116/40937805-73182796-6805-11e8-85be-7c41bbeebe9b.png)

Cuando se tiene activa la opcion Precios sin impuestos no hay problemas, pero cuando se activa la opcion Precios con Impuesto, el valor que sale en la linea de la factura es = 0.
![image](https://user-images.githubusercontent.com/7775116/40938105-716765be-6806-11e8-8c76-ec56b19ce68c.png)

Este PR agrega el calculo del nuevo campo tal como haria odoo de base.
TODO: entiendo que el [campo price_tax_included](https://github.com/dansanti/l10n_cl_fe/blob/11.0/models/invoice.py#L140) se agrego para guardar la misma informacion(el valor incluido el impuesto xq en versiones anteriores a V11 no existia dicho campo) pero ya en V11, ese campo estaria de mas, creo que seria complicado eliminar ese campo pero tener presente que se deberia eliminar en versiones futuras. Ademas que el campo que tu agregastes no se guarda en la BD(store=False), y el de odoo si se guarda en la BD(se usa en los reportes y analisis)